### PR TITLE
fix "Not in multipart mode " error

### DIFF
--- a/src/main/java/com/example/demo/email/EmailService.java
+++ b/src/main/java/com/example/demo/email/EmailService.java
@@ -26,7 +26,7 @@ public class EmailService implements EmailSender{
         try {
             MimeMessage mimeMessage = mailSender.createMimeMessage();
             MimeMessageHelper helper =
-                    new MimeMessageHelper(mimeMessage, "utf-8");
+                    new MimeMessageHelper(mimeMessage,true, "utf-8");
             helper.setText(email, true);
             helper.setTo(to);
             helper.setSubject("Confirm your email");


### PR DESCRIPTION
get the following error when sent a post request to `http://127.0.0.1:8080/api/v1/registration/`
```
 "status": 500,
    "error": "Internal Server Error",
    "message": "Not in multipart mode - create an appropriate MimeMessageHelper via a constructor that takes a 'multipart' flag if you need to set alternative texts or add inline elements or attachments.",
```